### PR TITLE
Fix navigation links for statement pages

### DIFF
--- a/BankApp-Eureka-Server/website/src/main/java/com/moneymoney/web/controller/BankAppController.java
+++ b/BankApp-Eureka-Server/website/src/main/java/com/moneymoney/web/controller/BankAppController.java
@@ -119,8 +119,8 @@ public class BankAppController {
 		CurrentDataSet currentDataSet = restTemplate.getForObject("http://transactions-service/transactions/statement", CurrentDataSet.class);
 		int currentSize=size==0?5:size;
 		int currentOffset=offset==0?1:offset;
-		Link next=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset+currentSize,currentSize)).withRel("next");
-		Link previous=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset-currentSize, currentSize)).withRel("previous");
+		Link next=linkTo(methodOn(BankAppController.class).getStatementWithdraw(currentOffset+currentSize,currentSize)).withRel("next");
+		Link previous=linkTo(methodOn(BankAppController.class).getStatementWithdraw(currentOffset-currentSize, currentSize)).withRel("previous");
 		List<Transaction> transactions = currentDataSet.getTransactions();
 		List<Transaction> currentDataSetList = new ArrayList<Transaction>();
 		
@@ -143,8 +143,8 @@ public class BankAppController {
 		CurrentDataSet currentDataSet = restTemplate.getForObject("http://transactions-service/transactions/statement", CurrentDataSet.class);
 		int currentSize=size==0?5:size;
 		int currentOffset=offset==0?1:offset;
-		Link next=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset+currentSize,currentSize)).withRel("next");
-		Link previous=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset-currentSize, currentSize)).withRel("previous");
+		Link next=linkTo(methodOn(BankAppController.class).getStatementFundTransfer(currentOffset+currentSize,currentSize)).withRel("next");
+		Link previous=linkTo(methodOn(BankAppController.class).getStatementFundTransfer(currentOffset-currentSize, currentSize)).withRel("previous");
 		List<Transaction> transactions = currentDataSet.getTransactions();
 		List<Transaction> currentDataSetList = new ArrayList<Transaction>();
 		
@@ -160,5 +160,4 @@ public class BankAppController {
 		 * currentDataSet.setNextLink(next); currentDataSet.setPreviousLink(previous);
 		 */
 		return new ModelAndView("DepositForm","currentDataSet",dataSet);
-	}
-}
+	}}

--- a/BankApp-Hystrix/website/src/main/java/com/moneymoney/web/controller/BankAppController.java
+++ b/BankApp-Hystrix/website/src/main/java/com/moneymoney/web/controller/BankAppController.java
@@ -187,8 +187,8 @@ public class BankAppController {
 		CurrentDataSet currentDataSet = restTemplate.getForObject("http://transactions-service/transactions/statement", CurrentDataSet.class);
 		int currentSize=size==0?5:size;
 		int currentOffset=offset==0?1:offset;
-		Link next=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset+currentSize,currentSize)).withRel("next");
-		Link previous=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset-currentSize, currentSize)).withRel("previous");
+		Link next=linkTo(methodOn(BankAppController.class).getStatementWithdraw(currentOffset+currentSize,currentSize)).withRel("next");
+		Link previous=linkTo(methodOn(BankAppController.class).getStatementWithdraw(currentOffset-currentSize, currentSize)).withRel("previous");
 		List<Transaction> transactions = currentDataSet.getTransactions();
 		List<Transaction> currentDataSetList = new ArrayList<Transaction>();
 		
@@ -212,8 +212,8 @@ public class BankAppController {
 	public ModelAndView fallbackWithdrawStatement(@RequestParam("offset") int offset, @RequestParam("size") int size) {
 		int currentSize=size==0?5:size;
 		int currentOffset=offset==0?1:offset;
-		Link next=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset+currentSize,currentSize)).withRel("next");
-		Link previous=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset-currentSize, currentSize)).withRel("previous");
+		Link next=linkTo(methodOn(BankAppController.class).getStatementWithdraw(currentOffset+currentSize,currentSize)).withRel("next");
+		Link previous=linkTo(methodOn(BankAppController.class).getStatementWithdraw(currentOffset-currentSize, currentSize)).withRel("previous");
 		
 		List<Transaction> currentDataSetList = new ArrayList<Transaction>();
 		
@@ -239,8 +239,8 @@ public class BankAppController {
 		CurrentDataSet currentDataSet = restTemplate.getForObject("http://transactions-service/transactions/statement", CurrentDataSet.class);
 		int currentSize=size==0?5:size;
 		int currentOffset=offset==0?1:offset;
-		Link next=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset+currentSize,currentSize)).withRel("next");
-		Link previous=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset-currentSize, currentSize)).withRel("previous");
+		Link next=linkTo(methodOn(BankAppController.class).getStatementFundTransfer(currentOffset+currentSize,currentSize)).withRel("next");
+		Link previous=linkTo(methodOn(BankAppController.class).getStatementFundTransfer(currentOffset-currentSize, currentSize)).withRel("previous");
 		List<Transaction> transactions = currentDataSet.getTransactions();
 		List<Transaction> currentDataSetList = new ArrayList<Transaction>();
 		
@@ -264,8 +264,8 @@ public class BankAppController {
 	public ModelAndView fallbackFundTransferStatement(@RequestParam("offset") int offset, @RequestParam("size") int size) {
 		int currentSize=size==0?5:size;
 		int currentOffset=offset==0?1:offset;
-		Link next=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset+currentSize,currentSize)).withRel("next");
-		Link previous=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset-currentSize, currentSize)).withRel("previous");
+		Link next=linkTo(methodOn(BankAppController.class).getStatementFundTransfer(currentOffset+currentSize,currentSize)).withRel("next");
+		Link previous=linkTo(methodOn(BankAppController.class).getStatementFundTransfer(currentOffset-currentSize, currentSize)).withRel("previous");
 		
 		List<Transaction> currentDataSetList = new ArrayList<Transaction>();
 		
@@ -283,5 +283,4 @@ public class BankAppController {
 		modelView.setViewName("FundTransferForm");
 		modelView.addObject("message","Statements not available ...try again later!!");
 		return modelView;
-	}
-}
+	}}

--- a/BankApp/website/src/main/java/com/moneymoney/web/controller/BankAppController.java
+++ b/BankApp/website/src/main/java/com/moneymoney/web/controller/BankAppController.java
@@ -199,8 +199,8 @@ public class BankAppController {
 		CurrentDataSet currentDataSet = storeData;
 		int currentSize=size==0?5:size;
 		int currentOffset=offset==0?1:offset;
-		Link next=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset+currentSize,currentSize)).withRel("next");
-		Link previous=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset-currentSize, currentSize)).withRel("previous");
+		Link next=linkTo(methodOn(BankAppController.class).getStatementWithdraw(currentOffset+currentSize,currentSize)).withRel("next");
+		Link previous=linkTo(methodOn(BankAppController.class).getStatementWithdraw(currentOffset-currentSize, currentSize)).withRel("previous");
 		List<Transaction> transactions = currentDataSet.getTransactions();
 		List<Transaction> currentDataSetList = new ArrayList<Transaction>();
 		
@@ -247,8 +247,8 @@ public class BankAppController {
 		CurrentDataSet currentDataSet = storeData;
 		int currentSize=size==0?5:size;
 		int currentOffset=offset==0?1:offset;
-		Link next=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset+currentSize,currentSize)).withRel("next");
-		Link previous=linkTo(methodOn(BankAppController.class).getStatementDeposit(currentOffset-currentSize, currentSize)).withRel("previous");
+		Link next=linkTo(methodOn(BankAppController.class).getStatementFundTransfer(currentOffset+currentSize,currentSize)).withRel("next");
+		Link previous=linkTo(methodOn(BankAppController.class).getStatementFundTransfer(currentOffset-currentSize, currentSize)).withRel("previous");
 		List<Transaction> transactions = currentDataSet.getTransactions();
 		List<Transaction> currentDataSetList = new ArrayList<Transaction>();
 		
@@ -265,5 +265,4 @@ public class BankAppController {
 		modelView.setViewName("FundTransferForm");
 		modelView.addObject("message","Updated statements not available ...try again later!!");
 		return modelView;
-	}
-}
+	}}


### PR DESCRIPTION
## Summary
- fix navigation links in BankApp website fallbacks
- update Hystrix website to use correct statement methods
- correct statement navigation in Eureka server website

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686df8f91af48327afacbd91f7924175