### PR TITLE
Fix transactionDetails parameter name

### DIFF
--- a/BankApp-Eureka-Server/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionService.java
+++ b/BankApp-Eureka-Server/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionService.java
@@ -9,9 +9,8 @@ public interface TransactionService {
 	
 	List<Transaction> getStatement(LocalDate startDate, LocalDate endDate);
 
-	Double withdraw(int accountNumber, String transactioDetails, double currentBalance, double amount);
+    Double withdraw(int accountNumber, String transactionDetails, double currentBalance, double amount);
 
-	Double deposit(int accountNumber, String transactioDetails, double currentBalance, double amount);
+    Double deposit(int accountNumber, String transactionDetails, double currentBalance, double amount);
 
-	List<Transaction> getStatement();
-}
+	List<Transaction> getStatement();}

--- a/BankApp-Eureka-Server/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionServiceImpl.java
+++ b/BankApp-Eureka-Server/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionServiceImpl.java
@@ -18,10 +18,11 @@ public class TransactionServiceImpl implements TransactionService {
 	private TransactionRepository repository;
 
 	@Override
-	public Double withdraw(int accountNumber,String transactioDetails,double currentBalance, double amount) {
-		Transaction transaction = new Transaction();
-		transaction.setAccountNumber(accountNumber);
-		transaction.setAmount(amount);
+    public Double withdraw(int accountNumber,String transactionDetails,double currentBalance, double amount) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountNumber(accountNumber);
+        transaction.setTransactionDetails(transactionDetails);
+        transaction.setAmount(amount);
 		currentBalance = currentBalance-amount;
 		transaction.setCurrentBalance(currentBalance);
 		transaction.setTransactionDate(LocalDateTime.now());
@@ -32,10 +33,11 @@ public class TransactionServiceImpl implements TransactionService {
 	}
 
 	@Override
-	public Double deposit(int accountNumber,String transactioDetails,double currentBalance, double amount) {
-		Transaction transaction = new Transaction();
-		transaction.setAccountNumber(accountNumber);
-		transaction.setAmount(amount);
+    public Double deposit(int accountNumber,String transactionDetails,double currentBalance, double amount) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountNumber(accountNumber);
+        transaction.setTransactionDetails(transactionDetails);
+        transaction.setAmount(amount);
 		currentBalance = currentBalance+amount;
 		transaction.setCurrentBalance(currentBalance);
 		transaction.setTransactionDate(LocalDateTime.now());

--- a/BankApp-Hystrix/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionService.java
+++ b/BankApp-Hystrix/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionService.java
@@ -9,9 +9,8 @@ public interface TransactionService {
 	
 	List<Transaction> getStatement(LocalDate startDate, LocalDate endDate);
 
-	Double withdraw(int accountNumber, String transactioDetails, double currentBalance, double amount);
+    Double withdraw(int accountNumber, String transactionDetails, double currentBalance, double amount);
 
-	Double deposit(int accountNumber, String transactioDetails, double currentBalance, double amount);
+    Double deposit(int accountNumber, String transactionDetails, double currentBalance, double amount);
 
-	List<Transaction> getStatement();
-}
+	List<Transaction> getStatement();}

--- a/BankApp-Hystrix/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionServiceImpl.java
+++ b/BankApp-Hystrix/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionServiceImpl.java
@@ -18,10 +18,11 @@ public class TransactionServiceImpl implements TransactionService {
 	private TransactionRepository repository;
 
 	@Override
-	public Double withdraw(int accountNumber,String transactioDetails,double currentBalance, double amount) {
-		Transaction transaction = new Transaction();
-		transaction.setAccountNumber(accountNumber);
-		transaction.setAmount(amount);
+    public Double withdraw(int accountNumber,String transactionDetails,double currentBalance, double amount) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountNumber(accountNumber);
+        transaction.setTransactionDetails(transactionDetails);
+        transaction.setAmount(amount);
 		currentBalance = currentBalance-amount;
 		transaction.setCurrentBalance(currentBalance);
 		transaction.setTransactionDate(LocalDateTime.now());
@@ -32,10 +33,11 @@ public class TransactionServiceImpl implements TransactionService {
 	}
 
 	@Override
-	public Double deposit(int accountNumber,String transactioDetails,double currentBalance, double amount) {
-		Transaction transaction = new Transaction();
-		transaction.setAccountNumber(accountNumber);
-		transaction.setAmount(amount);
+    public Double deposit(int accountNumber,String transactionDetails,double currentBalance, double amount) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountNumber(accountNumber);
+        transaction.setTransactionDetails(transactionDetails);
+        transaction.setAmount(amount);
 		currentBalance = currentBalance+amount;
 		transaction.setCurrentBalance(currentBalance);
 		transaction.setTransactionDate(LocalDateTime.now());

--- a/BankApp-Zuul-config-server-eureka-server/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionService.java
+++ b/BankApp-Zuul-config-server-eureka-server/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionService.java
@@ -9,9 +9,8 @@ public interface TransactionService {
 	
 	List<Transaction> getStatement(LocalDate startDate, LocalDate endDate);
 
-	Double withdraw(int accountNumber, String transactioDetails, double currentBalance, double amount);
+    Double withdraw(int accountNumber, String transactionDetails, double currentBalance, double amount);
 
-	Double deposit(int accountNumber, String transactioDetails, double currentBalance, double amount);
+    Double deposit(int accountNumber, String transactionDetails, double currentBalance, double amount);
 
-	List<Transaction> getStatement();
-}
+	List<Transaction> getStatement();}

--- a/BankApp-Zuul-config-server-eureka-server/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionServiceImpl.java
+++ b/BankApp-Zuul-config-server-eureka-server/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionServiceImpl.java
@@ -18,10 +18,11 @@ public class TransactionServiceImpl implements TransactionService {
 	private TransactionRepository repository;
 
 	@Override
-	public Double withdraw(int accountNumber,String transactioDetails,double currentBalance, double amount) {
-		Transaction transaction = new Transaction();
-		transaction.setAccountNumber(accountNumber);
-		transaction.setAmount(amount);
+    public Double withdraw(int accountNumber,String transactionDetails,double currentBalance, double amount) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountNumber(accountNumber);
+        transaction.setTransactionDetails(transactionDetails);
+        transaction.setAmount(amount);
 		currentBalance = currentBalance-amount;
 		transaction.setCurrentBalance(currentBalance);
 		transaction.setTransactionDate(LocalDateTime.now());
@@ -32,10 +33,11 @@ public class TransactionServiceImpl implements TransactionService {
 	}
 
 	@Override
-	public Double deposit(int accountNumber,String transactioDetails,double currentBalance, double amount) {
-		Transaction transaction = new Transaction();
-		transaction.setAccountNumber(accountNumber);
-		transaction.setAmount(amount);
+    public Double deposit(int accountNumber,String transactionDetails,double currentBalance, double amount) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountNumber(accountNumber);
+        transaction.setTransactionDetails(transactionDetails);
+        transaction.setAmount(amount);
 		currentBalance = currentBalance+amount;
 		transaction.setCurrentBalance(currentBalance);
 		transaction.setTransactionDate(LocalDateTime.now());

--- a/BankApp/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionService.java
+++ b/BankApp/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionService.java
@@ -9,9 +9,8 @@ public interface TransactionService {
 	
 	List<Transaction> getStatement(LocalDate startDate, LocalDate endDate);
 
-	Double withdraw(int accountNumber, String transactioDetails, double currentBalance, double amount);
+    Double withdraw(int accountNumber, String transactionDetails, double currentBalance, double amount);
 
-	Double deposit(int accountNumber, String transactioDetails, double currentBalance, double amount);
+    Double deposit(int accountNumber, String transactionDetails, double currentBalance, double amount);
 
-	List<Transaction> getStatement();
-}
+	List<Transaction> getStatement();}

--- a/BankApp/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionServiceImpl.java
+++ b/BankApp/transactions-service/src/main/java/com/moneymoney/app/transactionsservice/service/TransactionServiceImpl.java
@@ -18,10 +18,11 @@ public class TransactionServiceImpl implements TransactionService {
 	private TransactionRepository repository;
 
 	@Override
-	public Double withdraw(int accountNumber,String transactioDetails,double currentBalance, double amount) {
-		Transaction transaction = new Transaction();
-		transaction.setAccountNumber(accountNumber);
-		transaction.setAmount(amount);
+    public Double withdraw(int accountNumber,String transactionDetails,double currentBalance, double amount) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountNumber(accountNumber);
+        transaction.setTransactionDetails(transactionDetails);
+        transaction.setAmount(amount);
 		currentBalance = currentBalance-amount;
 		transaction.setCurrentBalance(currentBalance);
 		transaction.setTransactionDate(LocalDateTime.now());
@@ -32,10 +33,11 @@ public class TransactionServiceImpl implements TransactionService {
 	}
 
 	@Override
-	public Double deposit(int accountNumber,String transactioDetails,double currentBalance, double amount) {
-		Transaction transaction = new Transaction();
-		transaction.setAccountNumber(accountNumber);
-		transaction.setAmount(amount);
+    public Double deposit(int accountNumber,String transactionDetails,double currentBalance, double amount) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountNumber(accountNumber);
+        transaction.setTransactionDetails(transactionDetails);
+        transaction.setAmount(amount);
 		currentBalance = currentBalance+amount;
 		transaction.setCurrentBalance(currentBalance);
 		transaction.setTransactionDate(LocalDateTime.now());


### PR DESCRIPTION
## Summary
- update `TransactionService` interface parameter names
- update implementations to use `transactionDetails`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686df8e862fc83279556c54c70ad5dce