### PR TITLE
Fix employee deletion in rest-service

### DIFF
--- a/rest-service/src/main/java/com/cg/rest/restservice/service/EmployeeServiceImpl.java
+++ b/rest-service/src/main/java/com/cg/rest/restservice/service/EmployeeServiceImpl.java
@@ -30,11 +30,10 @@ public class EmployeeServiceImpl implements EmployeeService{
 		repository.save(employee);
 	}
 
-	@Override
-	public void deleteEmployee(int empId) {
-		Employee employee = repository.getOne(empId);
-		repository.delete(employee);
-	}
+        @Override
+        public void deleteEmployee(int empId) {
+                repository.deleteById(empId);
+        }
 
 	@Override
 	public Optional<Employee> getEmployee(int empId) {


### PR DESCRIPTION
## Summary
- fix employee delete operation to avoid lazy-loading errors

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686df61373d88327843088eb107ec464